### PR TITLE
remove enterprise repo body module

### DIFF
--- a/gitee/__init__.py
+++ b/gitee/__init__.py
@@ -66,8 +66,6 @@ from gitee.models.enterprise_basic import EnterpriseBasic
 from gitee.models.enterprise_member import EnterpriseMember
 from gitee.models.enterprise_members_body import EnterpriseMembersBody
 from gitee.models.enterprise_members_body1 import EnterpriseMembersBody1
-from gitee.models.enterprise_repos_body import EnterpriseReposBody
-from gitee.models.enterprise_repos_body1 import EnterpriseReposBody1
 from gitee.models.enterprise_week_report_body import EnterpriseWeekReportBody
 from gitee.models.enterprise_week_report_body1 import EnterpriseWeekReportBody1
 from gitee.models.event import Event

--- a/gitee/models/__init__.py
+++ b/gitee/models/__init__.py
@@ -46,8 +46,6 @@ from gitee.models.enterprise_basic import EnterpriseBasic
 from gitee.models.enterprise_member import EnterpriseMember
 from gitee.models.enterprise_members_body import EnterpriseMembersBody
 from gitee.models.enterprise_members_body1 import EnterpriseMembersBody1
-from gitee.models.enterprise_repos_body import EnterpriseReposBody
-from gitee.models.enterprise_repos_body1 import EnterpriseReposBody1
 from gitee.models.enterprise_week_report_body import EnterpriseWeekReportBody
 from gitee.models.enterprise_week_report_body1 import EnterpriseWeekReportBody1
 from gitee.models.event import Event


### PR DESCRIPTION
remove EnterpriseReposBody because the PrivateEnum is unkown. The api yaml file is not correct for some apis, so remove the relevant code temporally.